### PR TITLE
Roundtrip schemas

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -30,6 +30,9 @@ jobs:
         uses: actions/checkout@v2
         if: ${{ github.ref != 'refs/heads/main' }}
 
+      - name: REUSE Compliance Check
+        uses: fsfe/reuse-action@v1
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
@@ -40,9 +43,6 @@ jobs:
         run: dotnet build --no-restore
       - name: Test
         run: dotnet test --no-build --verbosity normal
-
-      - name: REUSE Compliance Check
-        uses: fsfe/reuse-action@v1
 
       # On main, let's build at least single-platform binaries.
       - name: Build artifacts

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -42,7 +42,7 @@ jobs:
         run: dotnet test --no-build --verbosity normal
 
       - name: REUSE Compliance Check
-        uses: fsfe/reuse-action@v1.1
+        uses: fsfe/reuse-action@v1
 
       # On main, let's build at least single-platform binaries.
       - name: Build artifacts

--- a/src/PrettyRegistryXml.Core/XmlRoundtripper.cs
+++ b/src/PrettyRegistryXml.Core/XmlRoundtripper.cs
@@ -1,0 +1,111 @@
+// Copyright 2021-2022 Collabora, Ltd
+//
+// SPDX-License-Identifier: MIT
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+namespace PrettyRegistryXml.Core
+{
+
+    /// <summary>
+    /// Provides a way to preserve leading "header" lines normally discarded by .NET XML parsing/writing.
+    /// </summary>
+    public class XmlRoundtripper
+    {
+
+        /// <summary>
+        /// Parse an XML file, and also load it into an XmlRoundtripper.
+        /// This overload assumes UTF-8
+        /// </summary>
+        /// <param name="filename">Path of an XML file to parse</param>
+        /// <param name="encoding">File encoding for reading and writing</param>
+        /// <param name="document">The document object to populate</param>
+        /// <returns>An object you can use to restore the header lines when writing out your document again.</returns>
+        public static XmlRoundtripper ParseAndLoad(string filename, Encoding encoding, out XDocument document)
+        {
+            using (var reader = new StreamReader(filename, encoding))
+            {
+                document = XDocument.Load(reader, LoadOptions.PreserveWhitespace);
+            }
+            return new XmlRoundtripper(new FileStream(filename, FileMode.Open, FileAccess.Read), encoding);
+        }
+
+        /// <summary>
+        /// Parse an XML file, and also load it into an XmlRoundtripper.
+        /// This overload assumes UTF-8.
+        /// </summary>
+        /// <param name="filename">Path of an XML file to parse</param>
+        /// <param name="document">The document object to populate</param>
+        /// <returns>An object you can use to restore the header lines when writing out your document again.</returns>
+        public static XmlRoundtripper ParseAndLoad(string filename, out XDocument document) => ParseAndLoad(filename, Encoding.UTF8, out document);
+
+        /// <summary>
+        /// Construct this object, storing the "header lines" (those that start with &lt;? or &lt;!) for later reuse.
+        /// If you want to also parse the XML into an <see cref="XDocument"/>, see <see cref="ParseAndLoad(string, Encoding, out XDocument)"/>.
+        /// </summary>
+        /// <param name="stream">A stream to read an XML file from</param>
+        /// <param name="encoding">The encoding to use when reading and writing</param>
+        public XmlRoundtripper(Stream stream, Encoding encoding)
+        {
+            _encoding = encoding;
+            _header = new(ReadLines(stream).TakeWhile(IsHeader));
+        }
+
+        /// <summary>
+        /// Construct this object, storing the "header lines" (those that start with &lt;? or &lt;!) for later reuse.
+        /// If you want to also parse the XML into an <see cref="XDocument"/>, see <see cref="ParseAndLoad(string, out XDocument)"/>.
+        /// Uses UTF-8 by default.
+        /// </summary>
+        /// <param name="stream">A stream to read an XML file from</param>
+        public XmlRoundtripper(Stream stream) : this(stream, Encoding.UTF8) { }
+
+        /// <summary>
+        /// Write a document to file, replacing the header lines with the ones from the original input.
+        /// </summary>
+        /// <param name="newDoc">The contents of the new document, after being formatted</param>
+        /// <param name="output">The stream to write the adjusted output to</param>
+        public void Write(string newDoc, Stream output)
+        {
+            var newDocStream = new MemoryStream(newDoc.Length);
+            using var writer = new StreamWriter(newDocStream, _encoding);
+            writer.WriteLine(newDoc);
+            writer.Flush();
+            // Move back to start.
+            newDocStream.Position = 0;
+
+            // Glue the stored header lines on the new lines excluding their header lines.
+            var newLines = _header.Concat(ReadLines(newDocStream).SkipWhile(IsHeader));
+
+            using var realWriter = new StreamWriter(output, _encoding);
+            foreach (var line in newLines)
+            {
+                realWriter.WriteLine(line.TrimEnd());
+            }
+        }
+
+        readonly Encoding _encoding;
+        readonly List<string> _header;
+
+        private static bool IsHeader(string line) => line.StartsWith("<?", StringComparison.InvariantCulture) || line.StartsWith("<!", StringComparison.InvariantCulture);
+
+        private static IEnumerable<string> ReadLines(Stream stream, Encoding encoding)
+        {
+            using var reader = new StreamReader(stream, encoding);
+            string? line = reader.ReadLine();
+            while (line != null)
+            {
+                yield return line;
+                line = reader.ReadLine();
+            }
+        }
+
+        private IEnumerable<string> ReadLines(Stream stream) => ReadLines(stream, _encoding);
+
+    }
+}

--- a/src/PrettyRegistryXml.OpenXR.Tests/PreserveSchemas.cs
+++ b/src/PrettyRegistryXml.OpenXR.Tests/PreserveSchemas.cs
@@ -1,0 +1,55 @@
+// Copyright 2021-2022 Collabora, Ltd
+//
+// SPDX-License-Identifier: MIT
+
+#nullable enable
+
+using System.Linq;
+using System.Collections.Generic;
+using Xunit;
+using System;
+using System.Reflection;
+using System.IO;
+
+
+namespace PrettyRegistryXml.OpenXR.Tests
+{
+    public class PreserveSchemasTest
+    {
+        private static string GetTestFileDir()
+        {
+            var assemblyPath = Uri.UnescapeDataString((new Uri(Assembly.GetExecutingAssembly().Location)).AbsolutePath);
+            return Path.Join(Path.GetDirectoryName(assemblyPath), "TestFiles");
+        }
+        private static string NormalizeText(string s)
+        {
+            return s.ReplaceLineEndings().Trim();
+        }
+
+        public static IEnumerable<object[]> RoundTripFilenames => new List<object[]>{
+            new object[] {
+                "sample.xml"
+            },
+        };
+        [Theory]
+        [MemberData(nameof(RoundTripFilenames))]
+        public void RoundtripData(string filename)
+        {
+            var fullPath = Path.Join(GetTestFileDir(), filename);
+            var outFullPath = fullPath + ".out";
+
+            var opts = new Options
+            {
+                InputFile = fullPath,
+                OutputFile = outFullPath,
+                WrapExtensions = false,
+                SortCodes = false,
+            };
+            Program.Run(opts);
+            var orig = File.ReadAllText(fullPath);
+            var formatted = File.ReadAllText(outFullPath);
+            Assert.Equal(NormalizeText(orig), NormalizeText(formatted));
+        }
+
+    }
+}

--- a/src/PrettyRegistryXml.OpenXR.Tests/PrettyRegistryXml.OpenXR.Tests.csproj
+++ b/src/PrettyRegistryXml.OpenXR.Tests/PrettyRegistryXml.OpenXR.Tests.csproj
@@ -23,6 +23,11 @@
     </PackageReference>
   </ItemGroup>
 
+  <!-- copy sample data for tests to use -->
+  <ItemGroup>
+    <None Include="TestFiles\**" CopyToOutputDirectory="PreserveNewest" LinkBase="TestFiles\" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\PrettyRegistryXml.OpenXR\PrettyRegistryXml.OpenXR.csproj" />
     <ProjectReference Include="..\PrettyRegistryXml.Core\PrettyRegistryXml.Core.csproj" />

--- a/src/PrettyRegistryXml.OpenXR.Tests/TestFiles/sample.xml
+++ b/src/PrettyRegistryXml.OpenXR.Tests/TestFiles/sample.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
+<?xml-model href="registry.rnc" type="application/relax-ng-compact-syntax"?>
+<?xml-model href="registry.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<registry>
+    <comment>
+Copyright (c) 2017-2022, The Khronos Group Inc.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+
+------------------------------------------------------------------------
+
+This file, xr.xml, is the OpenXR API Registry. It is a critically important
+and normative part of the OpenXR Specification, including a canonical
+machine-readable definition of the API, parameter and member validation
+language incorporated into the Specification and reference pages, and other
+material which is registered by Khronos, such as tags used by extension and
+layer authors. The only authoritative version of xr.xml is the one
+maintained in the default branch of the Khronos OpenXR GitHub project.
+    </comment>
+
+    <!-- SECTION: OpenXR vendor IDs for physical devices without PCI vendor IDs -->
+    <vendorids>
+        <vendorid name="KHR" id="0x10000" comment="This is the next available Khronos vendor ID"/>
+    </vendorids>
+</registry>

--- a/src/PrettyRegistryXml.OpenXR/Program.cs
+++ b/src/PrettyRegistryXml.OpenXR/Program.cs
@@ -2,36 +2,39 @@
 //
 // SPDX-License-Identifier: MIT
 
+using CommandLine;
+using PrettyRegistryXml.Core;
 using System;
 using System.IO;
-using System.Text;
 using System.Xml.Linq;
-using CommandLine;
 
 namespace PrettyRegistryXml.OpenXR
 {
-
+    /// <summary>
+    /// The main entry point class for the OpenXR registry formatter
+    /// </summary>
     public class Program
     {
 
+        /// <summary>
+        /// The inner method used to do the formatting once we have the options parsed.
+        /// </summary>
+        /// <param name="options"></param>
         public static void Run(Options options)
         {
             Console.WriteLine("Configuration:");
             Console.WriteLine(options.ToString());
             Console.WriteLine($"Reading registry from {options.InputFile}");
-            XDocument document;
-            using (var reader = new StreamReader(options.InputFile))
-            {
-                document = XDocument.Load(reader, LoadOptions.PreserveWhitespace);
-            }
+
+            var roundtripper = XmlRoundtripper.ParseAndLoad(options.InputFile, out XDocument document);
 
             Console.WriteLine("Processing with formatter");
             var formatter = new XmlFormatter(options);
             var result = formatter.Process(document);
 
             Console.WriteLine($"Writing processed registry to {options.ActualOutputFile}");
-            using var writer = new StreamWriter(options.ActualOutputFile, false, Encoding.UTF8);
-            writer.WriteLine(result);
+            using var outStream = new FileStream(options.ActualOutputFile, FileMode.Create, FileAccess.Write);
+            roundtripper.Write(result, outStream);
         }
 
         static void Main(string[] args)

--- a/src/PrettyRegistryXml.OpenXR/Program.cs
+++ b/src/PrettyRegistryXml.OpenXR/Program.cs
@@ -11,10 +11,10 @@ using CommandLine;
 namespace PrettyRegistryXml.OpenXR
 {
 
-    class Program
+    public class Program
     {
 
-        static void Run(Options options)
+        public static void Run(Options options)
         {
             Console.WriteLine("Configuration:");
             Console.WriteLine(options.ToString());


### PR DESCRIPTION
The special header lines in xml (processing directives?) were getting stripped by .NET. This forcibly puts them back.