### PR TITLE
Print usage if parse fails

### DIFF
--- a/src/PrettyRegistryXml.OpenXR/Program.cs
+++ b/src/PrettyRegistryXml.OpenXR/Program.cs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 using CommandLine;
+using CommandLine.Text;
 using PrettyRegistryXml.Core;
 using System;
 using System.IO;
@@ -39,11 +40,17 @@ namespace PrettyRegistryXml.OpenXR
 
         static void Main(string[] args)
         {
-            new Parser(with =>
-             {
-                 with.GetoptMode = true;
-             }).ParseArguments<Options>(args)
-                           .WithParsed(Run);
+            Parser parser = new Parser(with =>
+            {
+                with.GetoptMode = true;
+            });
+            ParserResult<Options> result = parser.ParseArguments<Options>(args);
+            if (result.Tag == ParserResultType.NotParsed)
+            {
+                Console.WriteLine(HelpText.AutoBuild(result));
+                return;
+            }
+            result.WithParsed(Run);
         }
     }
 }

--- a/src/PrettyRegistryXml.Vulkan/Program.cs
+++ b/src/PrettyRegistryXml.Vulkan/Program.cs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 using CommandLine;
+using CommandLine.Text;
 using PrettyRegistryXml.Core;
 using System;
 using System.IO;
@@ -33,11 +34,17 @@ namespace PrettyRegistryXml.Vulkan
 
         static void Main(string[] args)
         {
-            new Parser(with =>
-             {
-                 with.GetoptMode = true;
-             }).ParseArguments<Options>(args)
-                          .WithParsed(Run);
+            Parser parser = new Parser(with =>
+            {
+                with.GetoptMode = true;
+            });
+            ParserResult<Options> result = parser.ParseArguments<Options>(args);
+            if (result.Tag == ParserResultType.NotParsed)
+            {
+                Console.WriteLine(HelpText.AutoBuild(result));
+                return;
+            }
+            result.WithParsed(Run);
         }
     }
 }


### PR DESCRIPTION
I'm probably missing something silly but I wasn't getting usage information without parameters (as described in the README.md file). Can we deal with parse failures and print full usage in that case?