### PR TITLE
Bump CI scripts to build against .NET 8.0 (LTS)

### DIFF
--- a/.github/workflows/autofix-pulls.yml
+++ b/.github/workflows/autofix-pulls.yml
@@ -1,4 +1,4 @@
-# Copyright 2021-2024 Collabora, Ltd
+# Copyright 2021-2025 Collabora, Ltd
 #
 # SPDX-License-Identifier: MIT
 
@@ -26,7 +26,7 @@ jobs:
       - name: Setup .NET
         uses: "actions/setup-dotnet@v4"
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
       - name: Restore dependencies
         run: |
           dotnet restore

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -1,5 +1,5 @@
 # Copyright 2020 GitHub
-# Copyright 2021-2024 Collabora, Ltd
+# Copyright 2021-2025 Collabora, Ltd
 #
 # SPDX-License-Identifier: MIT
 
@@ -27,7 +27,7 @@ jobs:
       - name: Setup .NET
         uses: "actions/setup-dotnet@v4"
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
       - name: Restore dependencies
         run: dotnet restore
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,5 +1,5 @@
 # Copyright 2020 GitHub
-# Copyright 2021-2024 Collabora, Ltd
+# Copyright 2021-2025 Collabora, Ltd
 #
 # SPDX-License-Identifier: MIT
 
@@ -34,7 +34,7 @@ jobs:
       - name: Setup .NET
         uses: "actions/setup-dotnet@v4"
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
       - name: Restore dependencies
         run: dotnet restore
       - name: Build

--- a/Build-Docs.ps1
+++ b/Build-Docs.ps1
@@ -13,7 +13,7 @@ foreach ($srcdir in $dirs) {
     # Write-Output $srcdir
     $filename = $srcdir.BaseName + ".dll"
     $pathToSources = "../src/" + $srcdir.BaseName
-    $assemblypath = Join-Path $srcdir "bin/Debug/net6.0/$filename"
+    $assemblypath = Join-Path $srcdir "bin/Debug/net8.0/$filename"
     Write-Output $assemblypath
     dotnet tool run xmldocmd $assemblypath docs --source $pathToSources --clean
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,7 +23,7 @@
 
     <!-- build config -->
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <RootNamespace>PrettyRegistryXml</RootNamespace>
     </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Pretty Registry (for OpenXR and other Khronos standards)
 
 <!--
-Copyright 2021-2023, Collabora, Ltd
+Copyright 2021-2025, Collabora, Ltd
 
 SPDX-License-Identifier: CC-BY-4.0
 -->
@@ -17,11 +17,11 @@ point.
 
 ## Building and Running
 
-This uses the [.NET 6.0 SDK][dotnet] (formerly known as .NET Core - the
+This uses the [.NET 8.0 SDK][dotnet] (formerly known as .NET Core - the
 cross-platform open source one) SDK to build. That link has instructions to
 download and install it.
 
-Releases include binaries which only require the .NET 6.0 runtime, not the SDK,
+Releases include binaries which only require the .NET 8.0 runtime, not the SDK,
 and can be invoked just like any other command -- no need for the `dotnet`
 commands below. Running either the OpenXR or Vulkan tools with no arguments will
 show you help text.
@@ -63,7 +63,7 @@ dotnet run --project src/PrettyRegistryXml.Vulkan/PrettyRegistryXml.Vulkan.cspro
 
 By default, with no arguments you'll see help/usage.
 
-[dotnet]: https://dotnet.microsoft.com/download/dotnet/6.0
+[dotnet]: https://dotnet.microsoft.com/download/dotnet/8.0
 
 ## API Docs
 


### PR DESCRIPTION
6.0 is out of support.